### PR TITLE
Copying a nil pointer should result in a nil pointer.

### DIFF
--- a/deepcopy.go
+++ b/deepcopy.go
@@ -129,6 +129,9 @@ func _pointer(x interface{}, ptrs map[uintptr]interface{}) (interface{}, error) 
 	if v.Kind() != Ptr {
 		return nil, fmt.Errorf("must pass a value with kind of Ptr; got %v", v.Kind())
 	}
+	if v.IsNil() {
+		return nil, nil
+	}
 	addr := v.Pointer()
 	if dc, ok := ptrs[addr]; ok {
 		return dc, nil
@@ -165,7 +168,9 @@ func _struct(x interface{}, ptrs map[uintptr]interface{}) (interface{}, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to copy the field %v in the struct %#v: %v", t.Field(i).Name, x, err)
 		}
-		dc.Elem().Field(i).Set(ValueOf(item))
+		if item != nil {
+			dc.Elem().Field(i).Set(ValueOf(item))
+		}
 	}
 	return dc.Elem().Interface(), nil
 }

--- a/deepcopy_test.go
+++ b/deepcopy_test.go
@@ -57,10 +57,10 @@ func ExampleMap() {
 	}
 	// Output:
 	// x["foo"] = y["foo"]: false
-	// x["foo"].Foo = y["foo"].Foo: false
+	// x["foo"].Foo = y["foo"].Foo: true
 	// x["foo"].Bar = y["foo"].Bar: true
 	// x["bar"] = y["bar"]: false
-	// x["bar"].Foo = y["bar"].Foo: false
+	// x["bar"].Foo = y["bar"].Foo: true
 	// x["bar"].Bar = y["bar"].Bar: true
 }
 
@@ -150,5 +150,26 @@ func TestMismatchedTypesFail(t *testing.T) {
 				t.Errorf("%v attempted value %v as %v; should have gotten an error", test.kind, test.input, kind)
 			}
 		}
+	}
+}
+
+func TestCopyNilValue(t *testing.T) {
+	type Bar struct {
+		Baz string
+	}
+	type Foo struct {
+		Bar *Bar
+	}
+
+	s := &Foo{
+		Bar: nil,
+	}
+	c, err := Anything(s)
+	if err != nil {
+		t.Fatalf("deepcopy of struct %#v failed", s)
+	}
+
+	if !DeepEqual(s, c) {
+		t.Fatalf("original and copied struct are not equal: %+v != %+v", s, c)
 	}
 }


### PR DESCRIPTION
Previous behavior was that for a nil pointer in the original value a default struct was created.