### PR TITLE
Register custom type copiers

### DIFF
--- a/deepcopy.go
+++ b/deepcopy.go
@@ -38,9 +38,12 @@ func init() {
 		Struct:     _struct,
 	}
 
-	typeCopiers = map[Type]copier{
-		TypeOf(time.Time{}): _time,
-	}
+	typeCopiers = map[Type]copier{}
+	RegisterTypeCopier(TypeOf(time.Time{}), _time)
+}
+
+func RegisterTypeCopier(t Type, c copier) {
+	typeCopiers[t] = c
 }
 
 // MustAnything does a deep copy and panics on any errors.


### PR DESCRIPTION
Implements custom-type copier registration. Consumers will be able to register custom copiers if needed. 
ATM, we only have one use case: `StringArray` from the `pq` package, which is used in the data provider model. 
When used in the in-memory database, cloning with `deepcopy` would copy nil values into empty values, which is not what our tests expect. 
Alternatively, we could change the tests (not convenient) or check for `nil` value in the `_slice` implementation (pr here: https://github.com/cookieai-jar/go-deepcopy/pull/4). 
However, as we might bump into more use cases, we might need flexibility