### PR TITLE
EAC-41194: Fix cloning of nil maps

### DIFF
--- a/deepcopy.go
+++ b/deepcopy.go
@@ -132,6 +132,9 @@ func _map(x interface{}, ptrs map[uintptr]interface{}) (interface{}, error) {
 	if v.Kind() != Map {
 		return nil, fmt.Errorf("must pass a value with kind of Map; got %v", v.Kind())
 	}
+	if v.IsNil() {
+		return nil, nil
+	}
 	t := TypeOf(x)
 	dc := MakeMapWithSize(t, v.Len())
 	iter := v.MapRange()

--- a/deepcopy_test.go
+++ b/deepcopy_test.go
@@ -247,3 +247,14 @@ func TestTimePtrType(t *testing.T) {
 		t.Errorf("expect %v == %v; ", src, dst)
 	}
 }
+
+func TestNilMap(t *testing.T) {
+	var m map[string]string
+	dst, err := Anything(m)
+	if err != nil {
+		t.Errorf("expected no error; got %v", err)
+	}
+	if dst != nil {
+		t.Errorf("expected nil; got %v", dst)
+	}
+}


### PR DESCRIPTION
Nil maps should be cloned into nil maps, not empty maps.